### PR TITLE
Changed Old link to an active link

### DIFF
--- a/src/lab/exp8/Further Readings.html
+++ b/src/lab/exp8/Further Readings.html
@@ -99,7 +99,7 @@
 							
 							<!--edit -->
 <h1 class="text-h2-lightblue">Fine - grained POS Tagging</h1><div class="content" id="experiment-article-section-7-content">
-<center>http://www.comp.leeds.ac.uk/ccalas/tagsets/upenn.html<br/></center>
+<center>https://www.ling.upenn.edu/courses/Fall_2003/ling001/penn_treebank_pos.html<br/></center>
 <center>The University of Pennsylvania (Penn) Treebank Tag-set</center> <br/>
 <center>http://ltrc.iiit.ac.in/MachineTrans/publications/technicalReports/tr031/posguidelines.pdf</center>
 <center>AnnCorra : Guidelines For POS And Chunk Annotation For Indian Languages - Akshar Bharati, Dipti Misra Sharma, Lakshmi Bai, Rajeev Sangal</center>


### PR DESCRIPTION
#48
Found https://www.ling.upenn.edu/courses/Fall_2003/ling001/penn_treebank_pos.html , as a replacement for http://www.comp.leeds.ac.uk/ccalas/tagsets/upenn.html, which doesn't work anymore. 
I found the Penn tree bank by Googling and through the knowledge of what we used for CL1 course.

(Fixing #48)