### PR TITLE
Updated link to an active one

### DIFF
--- a/src/lab/exp8/Further Readings.html
+++ b/src/lab/exp8/Further Readings.html
@@ -101,7 +101,7 @@
 <h1 class="text-h2-lightblue">Fine - grained POS Tagging</h1><div class="content" id="experiment-article-section-7-content">
 <center>https://www.ling.upenn.edu/courses/Fall_2003/ling001/penn_treebank_pos.html<br/></center>
 <center>The University of Pennsylvania (Penn) Treebank Tag-set</center> <br/>
-<center>http://ltrc.iiit.ac.in/MachineTrans/publications/technicalReports/tr031/posguidelines.pdf</center>
+<center>https://researchweb.iiit.ac.in/~rashid.ahmedpg08/ilmtdocs/chunk-pos-ann-guidelines-15-Dec-06.pdf</center>
 <center>AnnCorra : Guidelines For POS And Chunk Annotation For Indian Languages - Akshar Bharati, Dipti Misra Sharma, Lakshmi Bai, Rajeev Sangal</center>
 </div>						</div>
 					</div>


### PR DESCRIPTION
#47 fixed, the new link was found on googling the intended PDF title.