### PR TITLE
Corpus absence hidden

### DIFF
--- a/src/lab/exp4/CLExperiment4.php
+++ b/src/lab/exp4/CLExperiment4.php
@@ -29,7 +29,7 @@ echo "<form action=\"javascript:selectLang()\" target=\"_parent\" method=\"post\
 echo "<select name=\"lang_opt\" id=\"lang_opt\" autocomplete=\"off\" onchange=\"selectLang(this.value);\">";
           echo "<option value=\"0\" select=\"selected\">---Select Language---</option>";
           echo "<option value=\"1\">English</option>";
-	  echo "<option value=\"2\">Hindi</option>";
+	#  echo "<option value=\"2\">Hindi</option>";
           
 echo "</select>"; ?>
 <br/><br/> 


### PR DESCRIPTION
Fix #49 , Since the corpus cant be loaded for some reason, and always throws "Error" on screen, I have commented it out from appearing as an option in the first place.